### PR TITLE
Feat: Harden git_sync.sh with improved security and logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The script is designed with modularity, security, and maintainability in mind.
     3.  **`git_sync.env` File**: Lowest priority. Provides default settings for a given environment.
 
 - **Security and Safety**:
-    - **Locking**: A file-based lock (`/tmp/git_sync.lock`) is used to prevent race conditions by ensuring only one instance of the script runs at a time. The lock is automatically released on script exit, error, or interruption.
+    - **Locking**: To prevent race conditions, the script uses an atomic, repository-specific locking mechanism. It creates a lock directory in a temporary directory (e.g., `/tmp`) with a unique name derived from the repository's path (e.g., `/tmp/git_sync_<repo_hash>.lockdir`). This ensures that synchronization operations for the same repository do not run concurrently, while allowing different repositories to be synced in parallel. The lock is automatically released on script exit, error, or interruption.
     - **Input Sanitization**: User-provided strings, such as the merge commit message, are sanitized to remove characters that could be used for command injection.
     - **Dangerous Operation Confirmation**: Potentially destructive operations like `fetch-reset` and `force` push require an explicit `--force-dangerous-operations` flag to prevent accidental data loss.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,17 +12,19 @@ This document provides solutions to common issues you may encounter when using t
 
 ---
 
-### 1. Lock File Exists
+### 1. Lock Directory Exists
 
--   **Error Message**: `Lock file found at /tmp/git_sync.lock. Another instance of git_sync.sh may be running.`
--   **Cause**: This error occurs if a previous run of the script was interrupted or if another instance is currently running. The lock file is a safety mechanism to prevent race conditions.
+-   **Error Message**: `Lock directory found at /tmp/git_sync_<repo_hash>.lockdir. Another instance of git_sync.sh may be running for this repository.`
+-   **Cause**: This error occurs if a previous run of the script for the same repository was interrupted or if another instance is currently running. The script creates a unique lock directory for each repository to prevent concurrent operations.
 -   **Solution**:
-    1.  First, verify that no other `git_sync.sh` process is running. You can check this using a command like `ps aux | grep git_sync.sh`.
-    2.  If you are certain no other instance is running, you can safely remove the lock file:
+    1.  First, verify that no other `git_sync.sh` process is running for this specific repository. You can check this using a command like `ps aux | grep git_sync.sh`.
+    2.  If you are certain no other instance is running, you can safely remove the lock directory. It is typically located in the `/tmp` directory (or the directory specified by the `$TMPDIR` environment variable) and is named `git_sync_<repo_hash>.lockdir`. The error message will show the exact path.
+    3.  To remove it, use the `rmdir` command with the full path from the error message:
         ```bash
-        rm /tmp/git_sync.lock
+        # Example:
+        rmdir /tmp/git_sync_a1b2c3d4e5f6.lockdir
         ```
-    3.  Rerun the script.
+    4.  Rerun the script.
 
 ---
 


### PR DESCRIPTION
This commit introduces several significant improvements to the `git_sync.sh` script to make it more secure and robust.

Key changes include:

1.  **Atomic Locking:** The locking mechanism has been refactored to use `mkdir`, which is an atomic operation. This prevents a Time-of-Check-to-Time-of-Use (TOCTOU) race condition that existed with the previous `touch`-based lock. The lock is now a directory with a `.lockdir` extension.

2.  **Argument Injection Prevention:** The `--` separator has been added to all relevant `git` commands (`clone`, `pull`, `push`, etc.) to ensure that user-provided arguments are always treated as values and not as options, preventing potential command injection.

3.  **Enhanced Error Handling:** The main operational calls (`pull_operation`, `push_operation`) are now explicitly checked for failure, providing clearer error messages to the user if a core git command fails.

4.  **Credential Warning:** A warning has been added to detect and notify the user if credentials are found embedded in the `REPO_URL`, encouraging the use of more secure methods like a credential helper.

5.  **Documentation Updates:** The `README.md` and `TROUBLESHOOTING.md` files have been updated to accurately reflect the new directory-based locking mechanism.